### PR TITLE
Remove simple-git-hooks configuration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@types/bun": "^1.3.4",
         "bumpp": "^10.3.2",
         "bunup": "^0.16.10",
-        "simple-git-hooks": "^2.13.1",
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
@@ -262,8 +261,6 @@
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "simple-git-hooks": ["simple-git-hooks@2.13.1", "", { "bin": { "simple-git-hooks": "cli.js" } }, "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 	"scripts": {
 		"build": "bunup",
 		"dev": "bunup --watch",
-		"postinstall": "bun simple-git-hooks",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
 		"release": "bumpp --commit --push --tag",
@@ -31,7 +30,6 @@
 		"@types/bun": "^1.3.4",
 		"bumpp": "^10.3.2",
 		"bunup": "^0.16.10",
-		"simple-git-hooks": "^2.13.1",
 		"typescript": "^5.9.3"
 	},
 	"peerDependencies": {
@@ -53,8 +51,5 @@
 		"./package.json": "./package.json"
 	},
 	"module": "./dist/index.js",
-	"simple-git-hooks": {
-		"pre-commit": "bun run lint && bun run type-check"
-	},
 	"types": "./dist/index.d.ts"
 }


### PR DESCRIPTION
## Description

Removes simple-git-hooks dependency and all associated git hook configuration from the project.

## Type of Change

- [x] 🔧 Build/CI

## Changes

- Removed `simple-git-hooks` from devDependencies
- Removed `postinstall` script that automatically set up hooks
- Removed `simple-git-hooks` configuration block with pre-commit hook definition

## Testing

- [x] All tests passing