### PR TITLE
fix: include src folder in published package for bun exports

### DIFF
--- a/packages/code-chunk/package.json
+++ b/packages/code-chunk/package.json
@@ -8,7 +8,8 @@
 	},
 	"license": "MIT",
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Problem

The `exports` field in `packages/code-chunk/package.json` defines a `bun` condition that points to `./src/index.ts`:

```json
"exports": {
  ".": {
    "bun": "./src/index.ts",
    ...
  }
}
```

However, the `files` array only includes `dist`:

```json
"files": ["dist"]
```

This means when users install `code-chunk` from npm, the `src/` folder is **not published**, causing Bun to fail with:

```
error: Cannot find package "code-chunk" from ...
```

## Solution

Add `src` to the `files` array so Bun can resolve the package correctly.

## Testing

Before fix:
```bash
bun add code-chunk
bun -e "import { chunk } from 'code-chunk'" 
# error: Cannot find package "code-chunk"
```

After fix:
```bash
bun -e "import { chunk } from 'code-chunk'; console.log(typeof chunk)"
# function
```