### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # code-chunk
 
+[![gitcgr](https://gitcgr.com/badge/supermemoryai/code-chunk.svg)](https://gitcgr.com/supermemoryai/code-chunk)
+
 AST-aware code chunking for semantic search and RAG pipelines.
 
 Uses tree-sitter to split source code at semantic boundaries (functions, classes, methods) rather than arbitrary character limits. Each chunk includes rich context: scope chain, imports, siblings, and entity signatures.


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/supermemoryai/code-chunk.svg)](https://gitcgr.com/supermemoryai/code-chunk)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).